### PR TITLE
Update support documentation to include Discord server as a resource

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Please review our [Code of Conduct](https://github.com/Neko-Nik/NIKL-Core/blob/m
 
 ## :bulb: Asking Questions
 
-See our [Support Guide](https://github.com/Neko-Nik/NIKL-Core/blob/main/SUPPORT.md). In short, GitHub issues are not the appropriate place to debug your specific project, but should be reserved for filing bugs and feature requests. Use [GitHub Discussions](https://github.com/Neko-Nik/NIKL-Core/discussions) for general questions and help.
+See our [Support Guide](https://github.com/Neko-Nik/NIKL-Core/blob/main/SUPPORT.md). In short, GitHub issues are not the appropriate place to debug your specific project, but should be reserved for filing bugs and feature requests. Use [GitHub Discussions](https://github.com/Neko-Nik/NIKL-Core/discussions) for general questions and help. Or ask in the [Neko Nik Discord Server](https://discord.gg/PYqHVUGdwv) examples are welcome in issues, but please do not post entire projects or large code snippets. If you need help with a specific problem, try to isolate the issue to a small code snippet that reproduces the problem. This will help us help you.
 
 ## :inbox_tray: Opening an Issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Please review our [Code of Conduct](https://github.com/Neko-Nik/NIKL-Core/blob/m
 
 ## :bulb: Asking Questions
 
-See our [Support Guide](https://github.com/Neko-Nik/NIKL-Core/blob/main/SUPPORT.md). In short, GitHub issues are not the appropriate place to debug your specific project, but should be reserved for filing bugs and feature requests. Use [GitHub Discussions](https://github.com/Neko-Nik/NIKL-Core/discussions) for general questions and help. Or ask in the [Neko Nik Discord Server](https://discord.gg/PYqHVUGdwv) examples are welcome in issues, but please do not post entire projects or large code snippets. If you need help with a specific problem, try to isolate the issue to a small code snippet that reproduces the problem. This will help us help you.
+See our [Support Guide](https://github.com/Neko-Nik/NIKL-Core/blob/main/SUPPORT.md). In short, GitHub issues are not the appropriate place to debug your specific project, but should be reserved for filing bugs and feature requests. Use [GitHub Discussions](https://github.com/Neko-Nik/NIKL-Core/discussions) for general questions and help. Or ask in the [Neko Nik Discord Server](https://discord.gg/PYqHVUGdwv). Examples are welcome in issues, but please do not post entire projects or large code snippets. If you need help with a specific problem, try to isolate the issue to a small code snippet that reproduces the problem. This will help us help you.
 
 ## :inbox_tray: Opening an Issue
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ The following domains and subdomains are officially owned and maintained by the 
 * [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=Neko-Nik.nikl-language-support) - **NIKL Language Support for Visual Studio Code**
 * [nikl-pkg.nekonik.com](https://nikl-pkg.nekonik.com) - **NIKL Package Manager** (Not yet live/implemented)
 * [api.nikl-pkg.nekonik.com](https://api.nikl-pkg.nekonik.com) - **NIKL Package Manager API** (Not yet live/implemented)
-* [Discord Server](https://discord.gg/PYqHVUGdwv) - **NIKL Discord Community**
+* [Neko Nik Discord Server](https://discord.gg/PYqHVUGdwv) - **Neko Nik Discord Community**
 * [forums.nekonik.com](https://forums.nekonik.com) - **Neko Nik Forums**
 
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ The following domains and subdomains are officially owned and maintained by the 
 * [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=Neko-Nik.nikl-language-support) - **NIKL Language Support for Visual Studio Code**
 * [nikl-pkg.nekonik.com](https://nikl-pkg.nekonik.com) - **NIKL Package Manager** (Not yet live/implemented)
 * [api.nikl-pkg.nekonik.com](https://api.nikl-pkg.nekonik.com) - **NIKL Package Manager API** (Not yet live/implemented)
+* [Discord Server](https://discord.gg/PYqHVUGdwv) - **NIKL Discord Community**
 * [forums.nekonik.com](https://forums.nekonik.com) - **Neko Nik Forums**
 
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,7 +5,7 @@ Need help getting started or using `NIKL`? Here's how.
 
 ## How to get help
 
-Use GitHub issues for **bug reports** and **feature requests**. For general questions, please use [GitHub Discussions](https://github.com/Neko-Nik/NIKL-Core/discussions). This is the best way to get help with the NIKL project.
+Use GitHub issues for **bug reports** and **feature requests**. For general questions, please use [GitHub Discussions](https://github.com/Neko-Nik/NIKL-Core/discussions). Or join the [Neko Nik Discord server](https://discord.gg/PYqHVUGdwv) to ask questions in the respective channel. This is the best way to get help with the NIKL project.
 
 
 ## How to ask for help
@@ -14,7 +14,7 @@ When asking for help, please follow these guidelines:
 
 1. :book: **Read the documentation and other guides** of NIKL to see if you can figure it out on your own. The documentation is available at [Nik-Lang Documentation](https://nikl.nekonik.com). See if there are any guides or tutorials that can help you.
 
-2. :bulb: **Search for answers and ask questions on [GitHub Discussions](https://github.com/Neko-Nik/NIKL-Core/discussions)**. This is the best place to ask general questions about Nik-Lang. You can also search for existing discussions to see if your question has already been answered.
+2. :bulb: **Search for answers and ask questions on [GitHub Discussions](https://github.com/Neko-Nik/NIKL-Core/discussions)**. This is the best place to ask general questions about Nik-Lang. You can also search for existing discussions to see if your question has already been answered. Or join the [Neko Nik Discord server](https://discord.gg/PYqHVUGdwv) to ask questions in the respective channel. The community is friendly and willing to help, so don't hesitate to ask!
 
 3. :memo: As a **last resort**, you may open an issue on [GitHub Issues](https://github.com/Neko-Nik/NIKL-Core/issues) to ask for help. However, please clearly explain what you are trying to do, and list what you have already attempted to solve the problem. Provide code samples, but **do not** attach your entire project for someone else to debug. Review our [contributing guidelines](https://github.com/Neko-Nik/NIKL-Core/blob/main/CONTRIBUTING.md).
 


### PR DESCRIPTION
This pull request introduces updates to the documentation to include the Neko Nik Discord server as an additional resource for community engagement and support. The most important changes involve adding references to the Discord server in relevant sections of the documentation.

### Documentation Updates:
* **CONTRIBUTING.md**: Added a reference to the Neko Nik Discord server as an additional platform for asking questions and getting help, while emphasizing the importance of isolating issues to small code snippets.
* **README.md**: Added the Neko Nik Discord server to the list of official resources under the community section.
* **SUPPORT.md**:
  - Updated the "How to get help" section to include the Discord server as an option for asking general questions.
  - Updated the "How to ask for help" section to encourage users to join the Discord server for community support and assistance.